### PR TITLE
moved template file locations and updated setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include requirements.txt
+include run_plot_dag.py
+include run_primrose.py
+include user_registration_template.py
+include README.md
+include config/*
+include data/*
+include templates/*

--- a/primrose/__init__.py
+++ b/primrose/__init__.py
@@ -121,7 +121,7 @@ def generate_run_script(destination):
     This will also allow you to register and use your own primrose node classes. 
     To register your own classes you will also need to run the primrose generate_class_registration_template command"""
     from shutil import copyfile
-    run_primrose_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../', 'run_primrose.py')
+    run_primrose_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'templates', 'run_primrose.py')
     copyfile(run_primrose_path, destination)
     print("Primrose's run_primrose.py script copied to " + destination)
     print("Don't forget to set where your new classes are to be imported. See script.")
@@ -133,7 +133,7 @@ def generate_class_registration_template(destination):
     """Create template to register your own classes. This will copy a template to your destination, such as src/__init__.py"""
     from shutil import copyfile
     user_registration_template_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                                   '../',
+                                                   'templates',
                                                    'user_registration_template.py')
     copyfile(user_registration_template_path, destination)
     print("Primrose's user_registration_template.py script copied to " + destination)
@@ -146,31 +146,39 @@ def create_project(name):
     from shutil import copyfile, copytree
 
     # get local directories to copy from the package dir
-    package_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../')
+    package_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'templates')
+    env_dir = sys.prefix
 
-    config_dir_path = os.path.join(package_dir, 'config')
+    config_dir_path = os.path.join(env_dir, 'config')
 
-    template_dir_path = os.path.join(package_dir, 'templates')
-
-    data_dir_path = os.path.join(package_dir, 'data')
+    data_dir_path = os.path.join(env_dir, 'data')
 
     user_registration_template_path = os.path.join(package_dir, 'user_registration_template.py')
 
     run_primrose_path = os.path.join(package_dir, 'run_primrose.py')
+
+    # make empty cache and src dir
+    os.makedirs(os.path.join(name, 'cache'))
+    os.makedirs(os.path.join(name, 'src', 'yourpackage'))
 
     # copy relevant files to user path
     copytree(config_dir_path, os.path.join(name, 'config'))
 
     copytree(data_dir_path, os.path.join(name, 'data'))
 
-    copytree(template_dir_path, os.path.join(name, 'src', 'yourpackage'))
+    copyfile(os.path.join(package_dir, 'awesome_model.py'), os.path.join(name,
+                                                                         'src',
+                                                                         'yourpackage',
+                                                                         'awesome_model.py'))
+
+    copyfile(os.path.join(package_dir, 'awesome_reader.py'), os.path.join(name,
+                                                                          'src',
+                                                                          'yourpackage',
+                                                                          'awesome_reader.py'))
 
     copyfile(user_registration_template_path, os.path.join(name, 'src', '__init__.py'))
 
     copyfile(run_primrose_path, os.path.join(name, 'run_primrose.py'))
-
-    # make empty cache dir
-    os.mkdir(os.path.join(name, 'cache'))
 
     # modify run_primrose to take into account the templated extention functions
     replacement_line = 'from src.__init__ import *\n'

--- a/primrose/templates/awesome_model.py
+++ b/primrose/templates/awesome_model.py
@@ -1,0 +1,66 @@
+"""Module with AbstractNode implementation, Example model for primrose user modification
+
+Author(s):
+    Mike Skarlinski (michael.skarlinski@ww.com)
+
+"""
+from primrose.base.model import AbstractModel
+
+
+class AwesomeModel(AbstractModel):
+    """(EXAMPLE MODEL) Print what is going on for each abstract method implementation
+
+    Notes:
+        see AbstractModel class to understand how this model is run in each mode!
+
+    """
+
+    @staticmethod
+    def necessary_config(node_config):
+        """Returns the necessary configuration keys for the AwesomeModel object
+
+        Put your required configuration keys here, here we pass just the base requirement from the abstract class
+
+        Args:
+            node_config (dict): set of parameters / attributes for the node
+
+        Note:
+            filename: name of the file
+
+        Returns:
+            set of necessary keys for the AwesomeModel object
+
+        """
+        return AbstractModel.necessary_config(node_config)
+
+    def train_model(self, data_object):
+        """Code to train your model and return a data_object after adding any training or model info"""
+
+        # Example model training code for building your own model
+        # ----------------------------------
+        print('I am training my model.')
+
+        # Example showing how to get upstream data
+        # get some training data if it exists
+        try:
+            training_data = data_object.get_upstream_data(self.instance_name)
+
+        except:
+            print('No upstream data exists')
+        # ----------------------------------
+
+        return data_object
+
+    def eval_model(self, data_object):
+        """Code to evaluate your models performance"""
+
+        print('My model is doing pretty well.')
+
+        return data_object
+
+    def predict(self, data_object):
+        """Make predictions using your model"""
+
+        print('I am predicting!')
+
+        return data_object

--- a/primrose/templates/awesome_reader.py
+++ b/primrose/templates/awesome_reader.py
@@ -1,0 +1,50 @@
+"""Module with AbstractNode implementation, Example for primrose user modification
+
+Author(s):
+    Mike Skarlinski (michael.skarlinski@ww.com)
+
+"""
+from primrose.base.reader import AbstractReader
+
+
+class AwesomeReader(AbstractReader):
+    """(EXAMPLE READER) Read input directly from the configuration file"""
+
+    @staticmethod
+    def necessary_config(node_config):
+        """Returns the necessary configuration keys for the AwesomeReader object
+
+        Put your required configuration keys here
+
+        Args:
+            node_config (dict): set of parameters / attributes for the node
+
+        Note:
+            filename: name of the file
+
+        Returns:
+            set of necessary keys for the AwesomeReader object
+
+        """
+        return set(['data_to_read'])
+
+    def run(self, data_object):
+        """Read data from node_config
+
+        Returns:
+            data_object (DataObject): DataObject instance
+            terminate (bool): should we terminate the DAG? true or false
+
+        """
+
+        # Example showing data being created directly from the config file
+        # any valid python can be used here for reading data into the data_object
+        # examples of other readers can be found in primrose/readers/*
+        # -------------------------------
+        data = self.node_config['data_to_read']
+        print('Reading in data!: {}'.format(data))
+        # -------------------------------
+        # add data into data object for use downstream
+        data_object.add(self, data)
+        terminate = data is None
+        return data_object, terminate

--- a/primrose/templates/run_plot_dag.py
+++ b/primrose/templates/run_plot_dag.py
@@ -1,0 +1,84 @@
+import logging
+import argparse
+
+from primrose.configuration.configuration import Configuration
+from primrose.dag.traverser_factory import TraverserFactory
+
+def parse_arguments():
+    """Parse command line arguments
+    Use environment variables as default if passed.
+    Returns: argument objects with flags as attributes
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config_loc',
+                        help='Location of the configuration file',
+                        required=True)
+    parser.add_argument('--node_size',
+                        help='Size of nodes',
+                        required=False)
+    parser.add_argument('--label_font_size',
+                        help='Size of font for text labels',
+                        required=False)
+    parser.add_argument('--text_angle',
+                        help='Angle to rotate text (counterclockwise)',
+                        required=False)
+    parser.add_argument('--image_width',
+                        help='width of image in inches',
+                        required=False)
+    parser.add_argument('--image_height',
+                        help='height of image in inches',
+                        required=False)
+    parser.add_argument('--nodesequence',
+                        help='Show node sequences numbers? "true" or "false"?',
+                        required=False)
+    parser.add_argument('--outfile',
+                        help='Path for the output image file',
+                        required=True)
+    known_args, pipeline_args = parser.parse_known_args()
+    return known_args, pipeline_args
+
+def main():
+    """Train, evaluate or predict with a machine learning model from a user defined data source
+        The function can optionally upload the results to an external source
+    """
+    args, _ = parse_arguments()
+
+    logging.basicConfig(format='%(asctime)s %(filename)s %(funcName)s: %(message)s', level=logging.INFO)
+    logging.getLogger().setLevel(logging.INFO)
+
+    config = Configuration(config_location=args.config_loc)
+
+    filename = args.outfile
+    other_args = {}
+    other_args['filename'] = args.outfile
+
+    if args.node_size:
+        other_args['node_size'] = int(args.node_size)
+
+    if args.label_font_size:
+        other_args['label_font_size'] = int(args.label_font_size)
+
+    if args.text_angle:
+        other_args['text_angle'] = int(args.text_angle)
+
+    if args.image_width:
+        other_args['image_width'] = int(args.image_width)
+
+    if args.image_height:
+        other_args['image_height'] = int(args.image_height)
+
+    other_args['traverser'] = None
+    if args.nodesequence and args.nodesequence.lower() == "true":
+        traverser = TraverserFactory().default_traverser(config)
+
+        if config.config_metadata and 'traverser' in config.config_metadata:
+            traverser = TraverserFactory().instantiate(config.config_metadata['traverser'], config)
+            logging.info("Setting to Traverser to %s", config.config_metadata['traverser'])
+
+        other_args['traverser'] = traverser
+
+    logging.info("passing in %s", other_args)
+    config.dag.plot_dag(**other_args)
+
+if __name__ == '__main__':
+    main()

--- a/primrose/templates/run_primrose.py
+++ b/primrose/templates/run_primrose.py
@@ -1,0 +1,59 @@
+'''
+    Run a job: i.e. run a configuration file through the DAGRunner
+'''
+import argparse
+import logging
+import warnings
+
+######################################
+######################################
+# Important:
+#     set where you registered your class here
+#
+# Example:
+#
+# from src.__init__ import *
+#
+######################################
+######################################
+
+from primrose.configuration.configuration import Configuration
+from primrose.dag_runner import DagRunner
+from primrose.dag.config_layer_traverser import ConfigLayerTraverser
+from primrose.dag.depth_first_traverser import DepthFirstTraverser
+
+warnings.filterwarnings("ignore")
+
+def parse_arguments():
+    """
+        Parse command line arguments
+
+        Returns:
+            argument objects with flags as attributes
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config_loc',
+                        help='Location of the configuration file',
+                        required=True)
+    parser.add_argument('--is_dry_run',
+                        help='do a dry run of the DAG which will validatre config and log which nodes would be run',
+                        default=False,
+                        type=lambda x: (str(x).lower() == 'true'))
+
+    known_args, pipeline_args = parser.parse_known_args()
+    return known_args, pipeline_args
+
+def main():
+    """
+        Run a job: i.e. run a configuration file through the DAGRunner
+    """
+    args, _ = parse_arguments()
+
+    logging.basicConfig(format='%(asctime)s %(levelname)s %(filename)s %(funcName)s: %(message)s', level=logging.INFO)
+
+    configuration = Configuration(config_location=args.config_loc)
+
+    DagRunner(configuration).run(dry_run=args.is_dry_run)
+
+if __name__ == '__main__':
+    main()

--- a/primrose/templates/user_registration_template.py
+++ b/primrose/templates/user_registration_template.py
@@ -1,0 +1,63 @@
+#########################################################################################
+#
+# This is a template to demonstrate how you can register your own primrose node classes
+#
+# Overview
+# ========
+# There are three steps to registering your own classes:
+#
+# 1) you need to generate a script to run primrose from your own project. To do that
+# run 
+# 
+#   primrose generate_script --destination path/to/myproject/
+# 
+# and it copies a run_primrose.py script to your project path
+#
+# 2) You need to register your own classes. This is the code in this script.
+#
+# 3) You need to reference this code in the run_primrose script.
+#
+# Step 1:
+# ========
+# run
+#
+#    primrose generate_script --destination path/to/myproject/
+#
+# which will create path/to/myproject/run_primrose.py
+#
+# Open up the file and see where it tells you to reference this code.
+#
+# Step2:
+# ========
+# Modify this file to register your own classes.
+# As can be seen below, 
+#  - you first need to import the NodeFactory singleton
+#  - next, import your new classes
+#  - finally, use NodeFactory to register those classes
+#
+# Step 3:
+# ========
+# *Importantly*, this factory registration has to occur *before* Configuration is instantiated
+# in the run_primrose script. 
+# To that end, we suggest putting this registration code below into something 
+# like `src/__init__.py` in your project. Wherever you put it, you will need to reference 
+# it in the run_primrose script.
+#
+# That is, if you put this code into `src/__init__.py`, you will need to add
+#
+#  from src.__init__ import *
+#
+# at the head of the run_primrose script. 
+#
+#########################################################################################
+
+import logging
+logging.basicConfig(format='%(asctime)s %(levelname)s %(filename)s %(funcName)s: %(message)s', level=logging.INFO)
+
+from primrose.node_factory import NodeFactory
+
+# Add your imports here
+from src.yourpackage.awesome_reader import AwesomeReader
+from src.yourpackage.awesome_model import AwesomeModel
+
+NodeFactory().register_module_classes(__name__)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ local_data_files = [os.path.join('data', f) for f in os.listdir('data')]
 local_config_files = [os.path.join('config', f) for f in os.listdir('config')]
 
 setup(name='primrose',
-      version='1.0.5',
+      version='1.0.4',
       description='Primrose: a framework for simple, quick modeling deployments',
       url='https://github.com/ww-tech/primrose',
       author='Carl Anderson',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+import os
 
 with open('README.md') as f:
     long_description = f.read()
@@ -6,8 +7,11 @@ with open('README.md') as f:
 with open('requirements.txt') as f:
     required = f.read().splitlines()
 
+local_data_files = [os.path.join('data', f) for f in os.listdir('data')]
+local_config_files = [os.path.join('config', f) for f in os.listdir('config')]
+
 setup(name='primrose',
-      version='1.0.0',
+      version='1.0.5',
       description='Primrose: a framework for simple, quick modeling deployments',
       url='https://github.com/ww-tech/primrose',
       author='Carl Anderson',
@@ -18,6 +22,9 @@ setup(name='primrose',
       zip_safe=False,
       install_requires=required,
       packages=find_packages(),
+      data_files=[('data', local_data_files),
+                  ('config', local_config_files)],
+      include_package_data=True,
       classifiers=[
         "Programming Language :: Python :: 3.6",
         "Operating System :: OS Independent"


### PR DESCRIPTION
We were unable access the config, data and template files in the previous structure of the primrose project. We needed to move these files into a usable location using the "data_files" option in setup.py, and move the top-level entrypoint files into the package itself so they could be installed via pip. 