### PR TITLE
Sql jinja templating

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ atlas>=0.27.0
 google-cloud-storage>=1.16.0
 pygraphviz>=1.5
 jstyleson==0.0.2
+Jinja2>=2.10


### PR DESCRIPTION
Enables ability for jinja templating within our sql queries. This allows for nesting queries inside of each other. 

For example, we have a primrose configuration use a jinja template referencing two queries, each with a parameter:
```
...
"query_json": [
    {
        "query": "sql_query_03.sql",
        "parameters": {
            "x": 4,
            "y": 5
        }
    }
]
...
```
Where:
```
# sql_query_01.sql
SELECT * from table_01 where x = {x}
```
```
# sql_query_02.sql
SELECT * from table_01 where y = {y}
```
```
# sql_query_03.sql
{% include 'sql_query_01.sql' %}
UNION ALL
{% include 'sql_query_02.sql' %}
```

The resulting query will render as:
```
SELECT * from table_01 where x = 4
UNION ALL
SELECT * from table_01 where y = 5
```

See [jinja2 documentation](https://jinja.palletsprojects.com/en/2.10.x/) for more examples of jinja templating.