### PR TITLE
Yaml config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,7 @@ dmypy.json
 
 # ignore cache created during tests
 cache/
+
+# IDE specific files
+.vscode/
+.idea/

--- a/README_DAG_CONFIG.md
+++ b/README_DAG_CONFIG.md
@@ -228,6 +228,7 @@ Other nodes may require many more additional fields than the single `filename` k
 Nodes may require other keys that are not required but are optional. For those keys, you will need to examine other configuration files or examine the source code.
 
 # Comments
+### YAML
 The `yaml` specification already provides support for commenting. Just use the `#` character to comment:
 
 ```
@@ -250,6 +251,7 @@ implementation_config:
       key: data
 ```
 
+### JSON
 `primrose` also supports javascript style comments in `json` configuration files. By making use of the `jstyleson` library, it supports `/*...*/` and `//` style comments:
  - single-line comment
  - multi-line comment

--- a/README_DAG_CONFIG.md
+++ b/README_DAG_CONFIG.md
@@ -15,6 +15,9 @@ Graphs consists of two components:
  ![](img/simple_graph.png)
 
  # Configuration Files
+
+ `primrose` configuration files can be defined using `json` or `yaml` format. This guide will detail `json` style configuration, but feel free to view example `yaml` configurations in the [config](./config) directory.
+
  At the highest level, configuration files consists of two sections:
 
   - **metadata** section. This section is *optional* and contains the data that defines any global (job-level) parameters. This section is documented [here](README_METADATA.md).
@@ -225,7 +228,29 @@ Other nodes may require many more additional fields than the single `filename` k
 Nodes may require other keys that are not required but are optional. For those keys, you will need to examine other configuration files or examine the source code.
 
 # Comments
-`primrose` supports javascript style comments in the configuration files. By making use of the `jstyleson` library, it supports `/*...*/` and `//` style comments:
+The `yaml` specification already provides support for commenting. Just use the `#` character to comment:
+
+```
+# this is a comment
+# this is too
+
+implementation_config:
+  # another comment
+  reader_config:
+    read_data:
+      class: CsvReader
+      destinations:
+      - write_output
+      filename: data/tennis.csv # inline comment
+  writer_config:
+    write_output:
+      class: CsvWriter
+      dir: cache
+      filename: tennis_output.csv # more comments
+      key: data
+```
+
+`primrose` also supports javascript style comments in `json` configuration files. By making use of the `jstyleson` library, it supports `/*...*/` and `//` style comments:
  - single-line comment
  - multi-line comment
  - inline comment
@@ -406,4 +431,4 @@ primrose.configuration.util.ConfigurationError: Did not find xxx destination in 
 ```
 
 ## Next
-Read more about the metadata featues of Configurations: [Configuration Metadata](README_METADATA.md)
+Read more about the metadata features of Configurations: [Configuration Metadata](README_METADATA.md)

--- a/README_METADATA.md
+++ b/README_METADATA.md
@@ -185,8 +185,8 @@ Putting this together, you might have configuration:
 ```
 which says cache after last step and write to `/tmp/data_object_20190618.dill`.
 
-## secton by section deveopment workflow
-Putting this togther, you might have a two stage development process.
+## section by section development workflow
+Putting this together, you might have a two stage development process.
 
 First, run `section1` only and cache the `DataObject` to `/tmp/data_object_20190618.dill`:
 
@@ -262,4 +262,4 @@ When you are satisfied with this `phase1` implementation, you can switch the con
 ```
 
 ## Next
-Learn about the [command line interace](README_CLI.md).
+Learn about the [command line interface](README_CLI.md).

--- a/config/hello_world_classifier_predict.yml
+++ b/config/hello_world_classifier_predict.yml
@@ -1,0 +1,43 @@
+metadata: {}
+implementation_config:
+  reader_config:
+    read_data:
+      class: CsvReader
+      destinations:
+      - encode_and_split
+      filename: data/tennis.csv
+    read_encoder:
+      class: DillReader
+      destinations:
+      - encode_and_split
+      filename: cache/hello_world_encoder.dill
+    read_model:
+      class: DillReader
+      destinations:
+      - decision_tree_model
+      filename: cache/hello_world_model.dill
+  pipeline_config:
+    encode_and_split:
+      class: EncodeTrainTestSplit
+      destinations:
+      - decision_tree_model
+      is_training: false
+      seed: 42
+      target_variable: play
+      training_fraction: 0.0
+  model_config:
+    decision_tree_model:
+      class: SklearnClassifierModel
+      cv_folds: null
+      destinations:
+      - write_output
+      grid_search_scoring: null
+      mode: predict
+      model_parameters: {}
+      sklearn_classifier_name: tree.DecisionTreeClassifier
+  writer_config:
+    write_output:
+      class: CsvWriter
+      dir: cache
+      filename: hello_world_predictions.csv
+      key: predictions

--- a/config/hello_world_classifier_train.yml
+++ b/config/hello_world_classifier_train.yml
@@ -1,0 +1,55 @@
+metadata: {}
+implementation_config:
+  reader_config:
+    read_data:
+      class: CsvReader
+      destinations:
+      - encode_and_split
+      filename: data/tennis.csv  
+  pipeline_config:
+    encode_and_split:
+      class: EncodeTrainTestSplit
+      destinations:
+      - decision_tree_model
+      - write_encoder
+      is_training: true
+      seed: 42
+      target_variable: play
+      training_fraction: 0.65
+  model_config:
+    decision_tree_model:
+      class: SklearnClassifierModel
+      cv_folds: 3
+      destinations:
+      - write_output
+      - write_model
+      grid_search_scoring: roc_auc
+      mode: train
+      model_parameters:
+        min_samples_leaf:
+        - 1
+        - 3
+        - 5
+        min_samples_split:
+        - 2
+        - 5
+        - 10
+        random_state:
+        - 42
+      sklearn_classifier_name: tree.DecisionTreeClassifier
+  writer_config:
+    write_encoder:
+      class: DillWriter
+      dir: cache
+      filename: hello_world_encoder.dill
+      key: transformer_sequence
+    write_model:
+      class: DillWriter
+      dir: cache
+      filename: hello_world_model.dill
+      key: model
+    write_output:
+      class: CsvWriter
+      dir: cache
+      filename: hello_world_predictions.csv
+      key: predictions

--- a/config/hello_world_cluster_eval.yml
+++ b/config/hello_world_cluster_eval.yml
@@ -1,0 +1,61 @@
+metadata: {
+        
+          # This is a minimal Sklearn clustering example in eval mode:
+          # read in some data from CSV
+          # use cached transformer_sequence no train test split!
+          # cluster with cached model
+          # predict on same training data, appending predictions column to data
+          # log some evaluation metrics
+          # save enriched data to CSV
+          # plot clusters and save image to disk
+
+}
+implementation_config:
+  reader_config:
+    read_data:
+      class: CsvReader
+      destinations:
+      - normalize_data
+      filename: data/unclustered.csv
+    read_encoder:
+      class: DillReader
+      destinations:
+      - normalize_data
+      filename: cache/hello_world_cluster_transformer.dill
+    read_model:
+      class: DillReader
+      destinations:
+      - cluster_model
+      filename: cache/hello_world_cluster_model.dill
+  pipeline_config:
+    normalize_data:
+      class: SklearnPreprocessingPipeline
+      destinations:
+      - cluster_model
+      is_training: false
+      operations: []
+      seed: 42
+      training_fraction: 0.0
+  model_config:
+    cluster_model:
+      class: SklearnClusterModel
+      destinations:
+      - write_data
+      - cluster_plotter
+      features:
+      - x1
+      - x2
+      mode: eval
+  dataviz_config:
+    cluster_plotter:
+      class: ClusterPlotter
+      filename: clusters.png
+      id_col: predictions
+      title: Results of KMeans(k=6)
+  writer_config:
+    write_data:
+      class: CsvWriter
+      dir: cache
+      filename: clustered_output.csv
+      key: data
+

--- a/config/hello_world_cluster_simple_train.yml
+++ b/config/hello_world_cluster_simple_train.yml
@@ -1,0 +1,61 @@
+metadata: {
+
+            # this is a minimal Sklearn clustering example in training mode:
+            # read in some data from CSV
+            # sklearn.preprocessing.StandardScaler transform the data but no train test split!
+            # cluster with sklearn.cluster.KMeans
+            # predict on same training data, appending predictions column to data
+            # save enriched data to CSV
+            # plot clusters and save image to disk
+
+}
+implementation_config:
+  reader_config:
+    read_data:
+      class: CsvReader
+      destinations:
+      - normalize_data
+      filename: data/unclustered.csv
+  pipeline_config:
+    normalize_data:
+      class: SklearnPreprocessingPipeline
+      destinations:
+      - cluster_model
+      is_training: true
+      operations:
+      - args:
+          with_mean: true
+          with_std: true
+        class: preprocessing.StandardScaler
+        columns:
+        - x1
+        - x2
+      seed: 42
+      training_fraction: 0.65
+  model_config:
+    cluster_model:
+      class: SklearnClusterModel
+      destinations:
+      - write_data
+      - cluster_plotter
+      features:
+      - x1
+      - x2
+      mode: train
+      model:
+        args:
+          n_clusters: 6
+          random_state: 42
+        class: cluster.KMeans
+  dataviz_config:
+    cluster_plotter:
+      class: ClusterPlotter
+      filename: clusters.png
+      id_col: predictions
+      title: Results of KMeans(k=6)
+  writer_config:
+    write_data:
+      class: CsvWriter
+      dir: cache
+      filename: clustered_output.csv
+      key: data

--- a/config/hello_world_cluster_train.yml
+++ b/config/hello_world_cluster_train.yml
@@ -1,0 +1,74 @@
+metadata: {
+
+          # this is a minimal Sklearn clustering example in training mode:
+          # read in some data from CSV
+          # sklearn.preprocessing.StandardScaler transform the data but no train test split!
+          # cluster with sklearn.cluster.KMeans
+          # predict on same training data, appending predictions column to data
+          # save enriched data to CSV
+          # save both transformer_sequence and model to disk
+          # plot clusters and save image to disk
+
+}
+implementation_config:
+  reader_config:
+    read_data:
+      class: CsvReader
+      destinations:
+      - normalize_data
+      filename: data/unclustered.csv
+  pipeline_config:
+    normalize_data:
+      class: SklearnPreprocessingPipeline
+      destinations:
+      - cluster_model
+      - write_transformer_sequence
+      is_training: true
+      operations:
+      - args:
+          with_mean: true
+          with_std: true
+        class: preprocessing.StandardScaler
+        columns:
+        - x1
+        - x2
+      seed: 42
+      training_fraction: 0.65
+  model_config:
+    cluster_model:
+      class: SklearnClusterModel
+      destinations:
+      - write_data
+      - write_model
+      - cluster_plotter
+      features:
+      - x1
+      - x2
+      mode: train
+      model:
+        args:
+          n_clusters: 6
+          random_state: 42
+        class: cluster.KMeans
+  dataviz_config:
+    cluster_plotter:
+      class: ClusterPlotter
+      filename: clusters.png
+      id_col: predictions
+      title: Results of KMeans(k=6)
+  writer_config:
+    write_data:
+      class: CsvWriter
+      dir: cache
+      filename: clustered_output.csv
+      key: data
+    write_model:
+      class: DillWriter
+      dir: cache
+      filename: hello_world_cluster_model.dill
+      key: model
+    write_transformer_sequence:
+      class: DillWriter
+      dir: cache
+      filename: hello_world_cluster_transformer.dill
+      key: transformer_sequence

--- a/config/hello_world_custom_nodes.yml
+++ b/config/hello_world_custom_nodes.yml
@@ -1,0 +1,20 @@
+metadata: {
+
+          # this is a minimal custom node example using the template nodes:
+          # AwesomeReader and AwesomeModel
+          # This reader and template don't do any useful behavior but it will get you started
+          # building your own nodes!
+
+}
+implementation_config:
+  reader_config:
+    my_reader:
+      class: AwesomeReader
+      data_to_read: Read me.
+      destinations:
+      - my_model
+  model_config:
+    my_model:
+      class: AwesomeModel
+      destinations: []
+      mode: train

--- a/config/hello_world_read_write.yml
+++ b/config/hello_world_read_write.yml
@@ -1,0 +1,15 @@
+# simple ETL: read from a CSV and then write data to a CSV
+
+implementation_config:
+  reader_config:
+    read_data:
+      class: CsvReader
+      destinations:
+      - write_output
+      filename: data/tennis.csv
+  writer_config:
+    write_output:
+      class: CsvWriter
+      dir: cache
+      filename: tennis_output.csv
+      key: data

--- a/config/hello_world_regression_train.yml
+++ b/config/hello_world_regression_train.yml
@@ -1,0 +1,50 @@
+metadata: {
+
+        #  this is a simple Sklearn regression example in train mode:
+        #  read in a sklearn dataset
+        #  do train test split
+        #  fit the regression on X_train, y_train with a sklearn linear estimator
+        #  log some evaluation metrics against X_test, y_test
+        #  save the model and transformer_sequence to disk
+
+}
+implementation_config:
+  reader_config:
+    read_data:
+      class: SklearnDatasetReader
+      dataset: iris
+      destinations:
+      - train_test_split
+  pipeline_config:
+    train_test_split:
+      class: TrainTestSplit
+      destinations:
+      - regression_model
+      - write_transformer_sequence
+      features:
+      - sepal length (cm)
+      - petal length (cm)
+      - petal width (cm)
+      is_training: true
+      seed: 42
+      target_variable: sepal width (cm)
+      training_fraction: 0.65
+  model_config:
+    regression_model:
+      class: SklearnRegressionModel
+      destinations:
+      - write_model
+      mode: train
+      model:
+        class: linear_model.LinearRegression
+  writer_config:
+    write_model:
+      class: DillWriter
+      dir: cache
+      filename: hello_world_regression_model.dill
+      key: model
+    write_transformer_sequence:
+      class: DillWriter
+      dir: cache
+      filename: hello_world_regression_transformer_sequence.dill
+      key: transformer_sequence

--- a/primrose/configuration/configuration.py
+++ b/primrose/configuration/configuration.py
@@ -10,6 +10,7 @@ import re
 import datetime
 import jstyleson
 import yaml
+import json
 import hashlib
 import os
 import logging
@@ -17,6 +18,9 @@ from primrose.node_factory import NodeFactory
 from primrose.configuration.util import OperationType, ConfigurationError, ConfigurationSectionType
 from primrose.configuration.configuration_dag import ConfigurationDag
 from primrose.dag.traverser_factory import TraverserFactory
+
+SUPPORTED_EXTS = frozenset(['.json', '.yaml', '.yml'])
+
 class Configuration:
     """Stores user defined configuration for primrose job"""
 
@@ -30,6 +34,8 @@ class Configuration:
 
         """
         if is_dict_config:
+            ext = None
+
             if dict_config is None:
                 raise Exception('expected dict_config was None')
 
@@ -39,27 +45,29 @@ class Configuration:
             dict_str = jstyleson.dumps(dict_config)
 
             config_str = Configuration.perform_any_config_fragment_substitution(dict_str)
+
         else:
             logging.info('Loading config file at {}'.format(config_location))
             self.config_location = config_location
-
+            
             if os.path.exists(config_location):
+                ext = os.path.splitext(config_location)[1].lower()
+                if ext not in SUPPORTED_EXTS:
+                    raise ValueError('config file at: {} has improper extension type - please use a .json or .yml file'.format(config_location))
+
                 with open(config_location, 'r') as f:
                     config_str = f.read()
 
                 config_str = Configuration.perform_any_config_fragment_substitution(config_str)
+
             else:
                 raise Exception('config file at: {} not found'.format(config_location))
-        
-        ext = os.path.splitext(config_str)[1].lower()
 
-        if ext == '.json':
+        if ext is None or ext == '.json':
             self.config = jstyleson.loads(config_str, object_pairs_hook=self.dict_raise_on_duplicates)
         elif ext in ['.yaml', '.yml']:
-            self.config = yaml.load(config_str)
-        else:
-            raise ValueError('config file at: {} has improper extension type - please use a .json or .yml file')
-        
+            self.config = yaml.load(config_str, Loader=yaml.FullLoader)
+
         assert isinstance(self.config, dict)
 
         # check top-level keys
@@ -119,7 +127,7 @@ class Configuration:
             config_str (str): the post-substituted configuration string
 
         """
-        matches = re.findall('.*?\$\$FILE=.*?\$\$.*?', config_str)
+        matches = re.findall(r'.*?\$\$FILE=.*?\$\$.*?', config_str)
 
         for match in matches:
             filename = match.split("$$FILE=")[1].split("$$")[0].strip()
@@ -167,7 +175,7 @@ class Configuration:
                 configuration_file_hashname (str): terminate the DAG?
 
         """
-        configuration_string = str(self.complete_config)
+        configuration_string = json.dumps(self.complete_config, sort_keys=True)
         configuration_file_hashname = hashlib.sha256(configuration_string.encode('utf-8')).hexdigest()
         return configuration_string, configuration_file_hashname
 

--- a/primrose/configuration/configuration.py
+++ b/primrose/configuration/configuration.py
@@ -9,6 +9,7 @@ Author(s):
 import re
 import datetime
 import jstyleson
+import yaml
 import hashlib
 import os
 import logging
@@ -49,9 +50,16 @@ class Configuration:
                 config_str = Configuration.perform_any_config_fragment_substitution(config_str)
             else:
                 raise Exception('config file at: {} not found'.format(config_location))
+        
+        ext = os.path.splitext(config_str)[1].lower()
 
-        self.config = jstyleson.loads(config_str, object_pairs_hook=self.dict_raise_on_duplicates)
-
+        if ext == '.json':
+            self.config = jstyleson.loads(config_str, object_pairs_hook=self.dict_raise_on_duplicates)
+        elif ext in ['.yaml', '.yml']:
+            self.config = yaml.load(config_str)
+        else:
+            raise ValueError('config file at: {} has improper extension type - please use a .json or .yml file')
+        
         assert isinstance(self.config, dict)
 
         # check top-level keys

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ google-cloud-storage>=1.16.0
 pygraphviz>=1.5
 jstyleson==0.0.2
 Jinja2>=2.10
+PyYAML>=5.1

--- a/test/config_substitution.yml
+++ b/test/config_substitution.yml
@@ -1,0 +1,3 @@
+$$FILE=test/metadata_fragment.yml$$
+implementation_config:
+  $$FILE= test/read_write_fragment.yml$$

--- a/test/hello_world_tennis.yml
+++ b/test/hello_world_tennis.yml
@@ -1,0 +1,55 @@
+metadata: {}
+implementation_config:
+  reader_config:
+    read_data:
+      class: CsvReader
+      destinations:
+      - encode_and_split
+      filename: data/tennis.csv
+  pipeline_config:
+    encode_and_split:
+      class: EncodeTrainTestSplit
+      destinations:
+      - decision_tree_model
+      - write_encoder
+      is_training: true
+      seed: 42
+      target_variable: play
+      training_fraction: 0.65
+  model_config:
+    decision_tree_model:
+      class: SklearnClassifierModel
+      cv_folds: 3
+      destinations:
+      - write_output
+      - write_model
+      grid_search_scoring: roc_auc
+      mode: train
+      model_parameters:
+        min_samples_leaf:
+        - 1
+        - 3
+        - 5
+        min_samples_split:
+        - 2
+        - 5
+        - 10
+        random_state:
+        - 42
+      sklearn_classifier_name: tree.DecisionTreeClassifier
+  writer_config:
+    write_encoder:
+      class: DillWriter
+      dir: cache
+      filename: hello_world_encoder.dill
+      key: transformer_sequence
+    write_model:
+      class: DillWriter
+      dir: cache
+      filename: hello_world_model.dill
+      key: model
+    write_output:
+      class: CsvWriter
+      dir: cache
+      filename: hello_world_predictions.csv
+      key: predictions

--- a/test/metadata_fragment.yml
+++ b/test/metadata_fragment.yml
@@ -1,0 +1,1 @@
+metadata: {}

--- a/test/read_write_fragment.yml
+++ b/test/read_write_fragment.yml
@@ -1,0 +1,12 @@
+  reader_config:
+    read_data:
+      class: CsvReader
+      destinations:
+      - write_output
+      filename: data/tennis.csv
+  writer_config:
+    write_output:
+      class: CsvWriter
+      dir: cache
+      filename: tennis_output.csv
+      key: data

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -57,6 +57,11 @@ def test_init_error7():
         Configuration(config_location=None, is_dict_config=True, dict_config=config)
     assert 'Unsupported top-level key: junk. Supported keys are [\'metadata\', \'implementation_config\']' in str(e)
 
+def test_init_error8():
+    with pytest.raises(ValueError) as e:
+        Configuration('test/tennis.csv')
+    assert 'config file at: test/tennis.csv has improper extension type - please use a .json or .yml file' in str(e)
+
 def test_metadata():
     config = {
         "metadata":{"k":"v"},
@@ -88,7 +93,7 @@ def test_init_ok2():
     }
     c = Configuration(config_location=None, is_dict_config=True, dict_config=config)
     assert c.config_string
-    assert c.config_hash == '85207f92c6f6401b3de785d900dc14d6412ca127626a422d186638a6b9c74431'
+    assert c.config_hash == 'b434870806fe0c61ddf2b417ae62c1be519b069fb6e12572f4ff8143f98086ff'
 
 def test_unrecognized():
     config = {
@@ -417,5 +422,40 @@ def test_perform_any_config_fragment_substitution():
         
         }
     }
+    """
+    assert final_str == expected
+
+def test_yaml_config1():
+    config_yaml = Configuration(config_location='test/hello_world_tennis.yml')
+    config_json = Configuration(config_location='test/hello_world_tennis.json')
+    assert config_yaml.config_hash == config_json.config_hash
+
+def test_yaml_config2():
+    c = Configuration('test/config_substitution.yml')
+    assert c.config_string
+    assert c.config_hash
+
+def test_yaml_perform_any_config_fragment_substitution():
+    config_str = """
+$$FILE=test/metadata_fragment.yml$$
+implementation_config:
+$$FILE= test/read_write_fragment.yml$$
+    """
+    final_str = Configuration.perform_any_config_fragment_substitution(config_str)
+    expected = """
+metadata: {}
+implementation_config:
+  reader_config:
+    read_data:
+      class: CsvReader
+      destinations:
+      - write_output
+      filename: data/tennis.csv
+  writer_config:
+    write_output:
+      class: CsvWriter
+      dir: cache
+      filename: tennis_output.csv
+      key: data
     """
     assert final_str == expected


### PR DESCRIPTION
The only caveat to this PR is the update in the configuration hash. Previously, the hash was calculated from the string representation of the configuration dict `str(self.complete_config)`. This is problematic because the `PyYAML` parser does not sort keys in the same order as the `jstyleson` parser. The fix is to change, the configuration string is sorted in the same way independent of how it is loaded:
```
configuration_string = json.dumps(self.complete_config, sort_keys=True)
```
This ensures that the same underlying configuration in a `yaml` file and a `json` file will share the same config hash.

This config hash change can also have a downstream impact if `primrose` users check configuration hash diffs. If a user runs a DAG of the same config file before and after this change, the config hash may be different.