### PR TITLE
Fix broken local test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ install:
   pip install -r requirements.txt
   
 script:
-- mkdir -p cache/
 - python -m pytest
 
 branches:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY primrose ./primrose
 COPY test ./test
-RUN mkdir cache
 
 RUN mkdir -p ~/.config/matplotlib && touch ~/.config/matplotlib/matplotlibrc
 RUN echo backend: Agg >> ~/.config/matplotlib/matplotlibrc

--- a/primrose/writers/abstract_file_writer.py
+++ b/primrose/writers/abstract_file_writer.py
@@ -4,10 +4,28 @@ Author(s):
     Carl Anderson (carl.anderson@weightwatchers.com)
 
 """
+import pathlib
 from primrose.base.writer import AbstractWriter
 
 class AbstractFileWriter(AbstractWriter):
     """write some data to a some file"""
+
+    def __init__(self,configuration, instance_name):
+        """
+
+        Args:
+            configuration (Configuration): configuration object defined in primrose/Configuration with validated inputs
+                from the result of necessary_config, all inputs are described in that method
+
+            instance_name (str): how the code knows where it is from
+
+        """
+        super().__init__(configuration, instance_name)
+        self._check_directory()
+
+    def _check_directory(self):
+        """Create directory or directory structure if it does not already exist."""
+        pathlib.Path(self.node_config['dir']).mkdir(parents=True, exist_ok=True)
 
     @staticmethod
     def necessary_config(node_config):


### PR DESCRIPTION
Closes Issue #5.

Added a `self._check_directory` method to `AbstractFileWriter`, called by the constructor, which will create the directory structure specified in `self.node_config['dir']`, if it does not already exists.  No more cache not existing errors hen running the test suite locally.