### PR TITLE
Fix a bug for the case when a transform occurs without the "to_numeric" keyword

### DIFF
--- a/primrose/transformers/categoricals.py
+++ b/primrose/transformers/categoricals.py
@@ -92,6 +92,7 @@ class ExplicitCategoricalTransform(AbstractTransformer):
 
         """
         if 'to_numeric' in input_data.keys():
+
             logging.info("Applying key {} to variable {}".format('to_numeric', name))
 
             if input_data['to_numeric']:
@@ -106,8 +107,12 @@ class ExplicitCategoricalTransform(AbstractTransformer):
                 try:
                     data[name] = pd.to_numeric(data[name])
                     return data
+
                 except:
                     raise TypeError('Failed to convert feature {} to numeric'.format(name))
+
+        else:
+            return data
 
     def transform(self, data):
         """Transform categorical variables into one or more numeric ones, no need to separate testing & training data

--- a/test/test_categoricals.py
+++ b/test/test_categoricals.py
@@ -44,6 +44,13 @@ def test__process_numeric():
 
     assert list(data.currency) == 3*[ExplicitCategoricalTransform.DEFAULT_NUMERIC]
 
+def test__process_numeric_no_config_key():
+    input_data = {}
+    data = pd.DataFrame(data={"currency": ['EUR', 'USD', 'USD']})
+    data = ExplicitCategoricalTransform._process_numeric(data, input_data, "currency")
+
+    assert data is not None
+
 def test__process_rename():
     input_data = {
         "transformations": [


### PR DESCRIPTION
A None type was returned by transform in that case, resulting in the break of the transformer pipeline for any explicit transform without the "to_numeric" key.