### PR TITLE
Jinja templating config file fragments

### DIFF
--- a/README_DAG_CONFIG.md
+++ b/README_DAG_CONFIG.md
@@ -290,18 +290,18 @@ Thus,
 will be parsed correctly as a JSON configuration.
 
 # Configuration File Fragment Substitution
-There are times when you may have a section of a configuration file that represents some coherent chunk of functionality that you would like to reuse in multiple configurations. `primrose` supports the ability to bring in that configuration fragment using string substitution. 
+There are times when you may have a section of a configuration file that represents some coherent chunk of functionality that you would like to reuse in multiple configurations. `primrose` supports the ability to bring in that configuration fragment using [jinja](https://jinja.palletsprojects.com/en/2.10.x/) substitution for both json and yaml config files. 
 
-It looks for the presence of `$$FILE=some/path/to/configuration/fragment.json$$` in your file.
+It looks for the presence of {% include some/path/to/configuration/fragment.json %} in your file.
 
 This is more easily explained with an example. 
 
 Suppose you have the following configuration file:
 ```
     {
-        $$FILE=test/metadata_fragment.json$$
+        {% include "test/metadata_fragment.json" %}
         "implementation_config": {
-            $$FILE= test/read_write_fragment.json $$
+            {% include "test/read_write_fragment.json" %}
         }
     }
 ```
@@ -329,7 +329,7 @@ and `test/read_write_fragment.json` is
                 }
             }
 ```
-`primrose` will swap `$$FILE=test/metadata_fragment.json$$` with the contents of `test/metadata_fragment.json` and it will swap `$$FILE= config/read_write_fragment.json $$` with the contents of `config/read_write_fragment.json` to produce:
+`primrose` will swap `{% include "test/metadata_fragment.json" %}` with the contents of `test/metadata_fragment.json` and it will swap `{% include "test/read_write_fragment.json" %}` with the contents of `config/read_write_fragment.json` to produce:
 ```
     {
         "metadata":{},

--- a/test/config_substitution.yml
+++ b/test/config_substitution.yml
@@ -1,3 +1,3 @@
-$$FILE=test/metadata_fragment.yml$$
+{% include "test/metadata_fragment.yml" %}
 implementation_config:
-  $$FILE= test/read_write_fragment.yml$$
+{% include "test/read_write_fragment.yml" %}

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -1,5 +1,6 @@
 import pytest
 import sys
+import json
 from primrose.configuration.configuration import Configuration
 from primrose.writers.abstract_file_writer import AbstractFileWriter
 
@@ -377,22 +378,22 @@ def test_comments_in_json():
 def test_perform_any_config_fragment_substitution_bad():
     config_str = """
     {
-        $$FILE=does/not/exist$$
+        {% include "does/not/exist" %}
         "implementation_config": {
         }
     }
     """
     with pytest.raises(Exception) as e:
         Configuration.perform_any_config_fragment_substitution(config_str)
-    assert 'Substitution files does not exist: does/not/exist' in str(e)
+    assert 'Substitution files do not exist: does/not/exist' in str(e)
 
 
 def test_perform_any_config_fragment_substitution():
     config_str = """
     {
-        $$FILE=test/metadata_fragment.json$$
+        {% include "test/metadata_fragment.json" %}
         "implementation_config": {
-            $$FILE= test/read_write_fragment.json $$
+            {% include "test/read_write_fragment.json" %}
         }
     }
     """
@@ -423,7 +424,7 @@ def test_perform_any_config_fragment_substitution():
         }
     }
     """
-    assert final_str == expected
+    assert json.loads(final_str) == json.loads(expected)
 
 def test_yaml_config1():
     config_yaml = Configuration(config_location='test/hello_world_tennis.yml')
@@ -437,9 +438,9 @@ def test_yaml_config2():
 
 def test_yaml_perform_any_config_fragment_substitution():
     config_str = """
-$$FILE=test/metadata_fragment.yml$$
+{% include "test/metadata_fragment.yml" %}
 implementation_config:
-$$FILE= test/read_write_fragment.yml$$
+{% include "test/read_write_fragment.yml" %}
     """
     final_str = Configuration.perform_any_config_fragment_substitution(config_str)
     expected = """


### PR DESCRIPTION
Closes Issue #10 

Switches to using jinja substitution for config file fragment substitution.

json
```
{
    {% include "test/metadata_fragment.json" %}
    "implementation_config": {
        {% include "test/read_write_fragment.json" %}
    }
}
```

yaml
```
{% include "test/metadata_fragment.yml" %}
implementation_config:
{% include "test/read_write_fragment.yml" %}
```