### PR TITLE
Fix docs index page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,7 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+docs
 
 # PyBuilder
 target/
@@ -115,6 +115,7 @@ venv.bak/
 # mkdocs documentation
 /site
 
+
 # mypy
 .mypy_cache/
 .dmypy.json
@@ -129,3 +130,5 @@ cache/
 # IDE specific files
 .vscode/
 .idea/
+
+

--- a/index.rst
+++ b/index.rst
@@ -13,7 +13,7 @@ Welcome to `primrose`! `Primrose` is a Python framework for executing in-memory 
 
 
 .. toctree::
-   :maxdepth: 8
+   :maxdepth: 2
    :caption: Contents:
 
    README.md


### PR DESCRIPTION
Cleaning up the docs.  The tree depth on the index page is set to a max of 8 and it looks bad.

Also git ignoring everything in the docs folder so you don't have to worry about running local doc builds and ignoring the build files