### PR TITLE
generalizing cluster predictions with no test data

### DIFF
--- a/primrose/dataviz/cluster_plotter.py
+++ b/primrose/dataviz/cluster_plotter.py
@@ -42,7 +42,6 @@ class ClusterPlotter(AbstractNode):
         X = dat['data']
         cluster_ids = X[self.node_config['id_col']]
         centers = X.groupby(self.node_config['id_col']).mean()
-        del X[self.node_config['id_col']]
 
         plt.scatter(X.iloc[:,0],X.iloc[:,1], c=cluster_ids, s=50, cmap='viridis')
         plt.scatter(centers.iloc[:,0], centers.iloc[:,1], c='black', s=200, alpha=0.5)

--- a/primrose/models/sklearn_cluster_model.py
+++ b/primrose/models/sklearn_cluster_model.py
@@ -28,6 +28,61 @@ class SklearnClusterModel(SklearnModel):
         """fit training data to model"""
         self.model.fit(self.X_train)
 
+    def _make_predictions(self, data_object):
+        """Make predictions
+
+        Args:
+            data_object (DataObject): instance of DataObject
+
+        Returns:
+            nothing. Predictions stored in self.predictions
+
+        """
+        if hasattr(self, 'predictions') and self.predictions is not None:
+            return
+
+        if self.model is None:
+            self.model = self.load_model(data_object)
+
+        self.X_train, self.y_train, self.X_test, self.y_test = self._get_data(data_object)
+
+        logging.info("Making predictions with model")
+        to_predict = self.X_test
+
+        if self.X_test is None:
+            to_predict = self.X_train
+            self.predictions = self.model.labels_
+        else:
+            self.predictions = self.model.predict(self.X_test)
+
+    def predict(self, data_object, load_model=False, use_serial=False):
+        """Predict y_test from X_test
+
+        Args:
+            data_object (DataObject): instance of DataObject
+
+            load_model: load model object from gcs or not
+
+        Returns: 
+            data_object (DataObject): instance of DataObject
+
+        """
+        self._make_predictions(data_object)
+        
+        if self.X_test is None:
+            data = self.X_train
+            if self.y_train is not None:
+                data['actual'] = self.y_train
+        else:
+            data = self.X_test
+            if self.y_test is not None:
+                data['actual'] = self.y_test
+
+        data['predictions'] = self.predictions
+        
+        data_object.add(self, data)
+        return data_object
+
     def get_scores(self):
         """get the scores for X_test
         
@@ -35,4 +90,7 @@ class SklearnClusterModel(SklearnModel):
             returns a dictionary of scors
         
         """
-        return SklearnModel.evaluate_no_ground_truth_classifier_metrics(self.X_test, self.predictions)
+        data = self.X_test
+        if self.X_test is None:
+            data = self.X_train
+        return SklearnModel.evaluate_no_ground_truth_classifier_metrics(data, self.predictions)

--- a/primrose/models/sklearn_model.py
+++ b/primrose/models/sklearn_model.py
@@ -96,8 +96,9 @@ class SklearnModel(AbstractModel):
 
         """
 
-        # get upstream data dict which contains the subkey data_test
-        data = data_object.get_filtered_upstream_data(self.instance_name, 'data_test')
+        # get upstream data dict which contains the subkey data_test or data_train
+        data = (data_object.get_filtered_upstream_data(self.instance_name, 'data_test') or 
+                data_object.get_filtered_upstream_data(self.instance_name, 'data_train'))
 
         X_train = None
         if 'data_train' in data:
@@ -144,7 +145,7 @@ class SklearnModel(AbstractModel):
         if 'args' in self.node_config['model']:
             args = self.node_config['model']['args']
 
-        self.model = SklearnModel._instantiate_model(self.node_config['model']['class'], args)
+        self.model = self._instantiate_model(self.node_config['model']['class'], args)
 
         logging.info("Fitting model")
         self.fit_training_data() #delegate down as args to self.model.fit() vary by model

--- a/primrose/pipelines/sklearn_preprocessing_pipeline.py
+++ b/primrose/pipelines/sklearn_preprocessing_pipeline.py
@@ -36,7 +36,7 @@ class SklearnPreprocessingPipeline(TrainTestSplit):
             args = operation.get('args', None)
             columns = operation.get('columns', None)
             
-            p = SklearnPreprocessingPipeline._instantiate_preprocessor(operation['class'], args, columns)
+            p = self._instantiate_preprocessor(operation['class'], args, columns)
             ts.add(p)
 
         return ts


### PR DESCRIPTION
`sklearn_model.py` and `sklearn_preprocessing_pipeline.py` - generalize to use `self` instead of class. This allows for parent classes to override the method with the same signature. Also allow models to find upstream data with no test set.

`sklearn_cluster_model.py` - update predictions. Before would inherit from `SklearnModel`, now implement own class. This is to allow for not using test data - if we want to cluster all train data. Instead of predictions, we return the attribute `self.model.labels_` which is available in all sklearn clustering models.

