### PR TITLE
reset index after upstream concat

### DIFF
--- a/primrose/pipelines/train_test_split.py
+++ b/primrose/pipelines/train_test_split.py
@@ -83,7 +83,7 @@ class TrainTestSplit(AbstractPipeline):
         else:
             if 'target_variable' in self.node_config:
                 data_train, data_test, target_train, target_test = train_test_split(
-                    data[sorted(list(set(data.columns) - set([self.node_config['target_variable']])))],
+                    data[sorted(list(set(data.columns) - set([self.node_config.get('target_variable')])))],
                     data[self.node_config['target_variable']],
                     test_size=(1.0 - float(self.node_config['training_fraction'])),
                     random_state=self.node_config['seed'])
@@ -94,7 +94,7 @@ class TrainTestSplit(AbstractPipeline):
 
             else:
                 data_train, data_test = train_test_split(
-                    data[sorted(list(set(data.columns) - set([self.node_config['target_variable']])))],
+                    data[sorted(list(set(data.columns) - set([self.node_config.get('target_variable')])))],
                     test_size=(1.0 - float(self.node_config['training_fraction'])),
                     random_state=self.node_config['seed'])
 

--- a/primrose/pipelines/train_test_split.py
+++ b/primrose/pipelines/train_test_split.py
@@ -83,7 +83,7 @@ class TrainTestSplit(AbstractPipeline):
         else:
             if 'target_variable' in self.node_config:
                 data_train, data_test, target_train, target_test = train_test_split(
-                    data[self.features(data)],
+                    data[sorted(list(set(data.columns) - set([self.node_config['target_variable']])))],
                     data[self.node_config['target_variable']],
                     test_size=(1.0 - float(self.node_config['training_fraction'])),
                     random_state=self.node_config['seed'])
@@ -94,7 +94,7 @@ class TrainTestSplit(AbstractPipeline):
 
             else:
                 data_train, data_test = train_test_split(
-                    data[self.features(data)],
+                    data[sorted(list(set(data.columns) - set([self.node_config['target_variable']])))],
                     test_size=(1.0 - float(self.node_config['training_fraction'])),
                     random_state=self.node_config['seed'])
 
@@ -152,7 +152,7 @@ class TrainTestSplit(AbstractPipeline):
 
                     dataframes_to_join.append(data[source][key])
 
-        return pd.concat(dataframes_to_join)
+        return pd.concat(dataframes_to_join).reset_index(drop=True)
 
     def fit_transform(self, data_object):
         """Split data into testing and training sets, then applies the categorical transform to each

--- a/test/test_sklearn_classifier_model.py
+++ b/test/test_sklearn_classifier_model.py
@@ -44,16 +44,16 @@ def test_train_model(model, data_obj):
     assert model.model is not None
     x_train, y_train, x_test, y_test = model._get_data(data_obj)
     predictions = model.model.predict(x_test)
-    assert list(predictions) == [1, 1, 0, 1, 1]
+    assert list(predictions) == [1, 0, 0, 1, 1]
 
 
 def test_eval(model, data_obj):
     model.train_model(data_obj)
     model.eval_model(data_obj)
     print(model.scores)
-    assert model.scores['recall'] == 1.0
-    assert model.scores['precision'] == 0.75
-    assert model.scores['predicted_class_fraction'] == 0.8
+    assert round(model.scores['recall'], 2) == 0.67
+    assert round(model.scores['precision'], 2) == 0.67
+    assert model.scores['predicted_class_fraction'] == 0.6
     assert model.scores['positive_class_fraction'] == 0.6
 
 
@@ -63,4 +63,4 @@ def test_predict(model, data_obj):
     predicted = data_object.get('decision_tree_model', rtype=DataObjectResponseType.KEY_VALUE.value)
 
     assert predicted['predictions'].shape[0] == 5
-    assert list(predicted['predictions'].predictions) == ['yes', 'yes', 'no', 'yes', 'yes']
+    assert list(predicted['predictions'].predictions) == ['yes', 'no', 'no', 'yes', 'yes']


### PR DESCRIPTION
Quick fix to reset the index after upstream data concatenation. This allows for downstream processing to be based on a unique index id if necessary.

Additionally performs train/test split on all available columns, except for the target column.
```
data[sorted(list(set(data.columns) - set([self.node_config['target_variable']])))]
```
Due to the way column sampling is implemented in the decision tree, the columns are sorted and the tests were updated so we could always have reproducible results.

The feature subset of the data occurs further in the pipeline, when it is added to the dataobject:
```
data_object.add(self, train_data[self.features(train_data)], key='data_train', overwrite=False)
```

The idea here is to allow `train_data` to have any supplemental columns needed during the `final_data_object_additions` phase of the pipeline. Previously, if the data object was not in the features list, it could not be selected from self.data.

<!--- 'Closes Issue #<number here> if applicable.' -->
Closes #72 

### Types of change
Bugfix:
- fixes issue where there is repeated indices in train_test_split dataframes
- fixes issue where data is unavailable for `final_data_object_additions`

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I squashed my commits to a reasonable number of descriptive commits.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

<!--- Note: I copied this from the Spacy repo, and modified sightly for our rules. So credit to them!-->