### PR TITLE
fixing small bug in categorical logging statement

### DIFF
--- a/primrose/transformers/categoricals.py
+++ b/primrose/transformers/categoricals.py
@@ -101,7 +101,7 @@ class ExplicitCategoricalTransform(AbstractTransformer):
                 if sum(pd.to_numeric(data[name], errors='coerce').isnull()) > 0:
                     logging.info("Can't convert these entries in {}. Replacing with {}: {}".format(
                         name, ExplicitCategoricalTransform.DEFAULT_NUMERIC,
-                        np.unique(data[name][pd.to_numeric(data[name], errors='coerce').isnull()])))
+                        np.unique(data[name][pd.to_numeric(data[name], errors='coerce').isnull()].astype(str))))
 
                     data[name][pd.to_numeric(data[name], errors='coerce').isnull()] = ExplicitCategoricalTransform.DEFAULT_NUMERIC
                 try:


### PR DESCRIPTION
### Description

When we log null replacements in the categorical transformer, `np.unique` does not support multiple dtypes and throws an error, cancelling the DAG. One example where we may have mixed dtypes is if there are float values (`np.nan`) as well as string values for categorical columns. This fix just casts the series to string for logging.

### Types of change
Bugfix - no new docs required.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I squashed my commits to a reasonable number of descriptive commits.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

<!--- Note: I copied this from the Spacy repo, and modified sightly for our rules. So credit to them!-->