### PR TITLE
adding limit to R version - new version might be breaking builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ install:
     elif [ $TRAVIS_OS_NAME = 'osx' ]; then
       brew install r
     fi
-    pip install rpy2>=2.9.1
+    pip install "rpy2>=2.9.1,<=3.2.7"
   elif [ $PYPI_BUILD = 'only_postgres' ]; then
     echo "Installing postgres requirements"
     pip install psycopg2>=2.8.3
@@ -118,7 +118,7 @@ install:
     elif [ $TRAVIS_OS_NAME = 'osx' ]; then
       brew install r
     fi
-    pip install rpy2>=2.9.1
+    pip install "rpy2>=2.9.1,<=3.2.7"
   fi
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='primrose',
       extras_require={
         'postgres': ["psycopg2>=2.8.3", "psycopg2_binary>=2.8.2"],
         'plotting': ["pygraphviz>=1.5"],
-        'R': ["rpy2>=2.9.1"],
-        'all': ["psycopg2>=2.8.3", "psycopg2_binary>=2.8.2", "pygraphviz>=1.5", "rpy2>=2.9.1"]
+        'R': ["rpy2>=2.9.1,<=3.2.7"],
+        'all': ["psycopg2>=2.8.3", "psycopg2_binary>=2.8.2", "pygraphviz>=1.5", "rpy2>=2.9.1,<=3.2.7"]
       }
     )


### PR DESCRIPTION
Limiting rpy2 version in attempt to fix failing tests. Not sure what the underlying issue is, but seeing as new versions were released on April 12th and we only failed after that release, I am putting an upper bound on the rpy2 version.

Wait for successful build to merge, otherwise we need further investigation.

EDIT: Looks like this was in fact the issue - something changed in the new `rpy2` version.

### Types of change
Bugfix - failing rpy2 tests on linux environments

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I squashed my commits to a reasonable number of descriptive commits.
- [x] I ran the tests, and all new and existing tests passed (local macOS).
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

<!--- Note: I copied this from the Spacy repo, and modified sightly for our rules. So credit to them!-->