### PR TITLE
Update pytest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ numpy>=1.16.4
 pandas>=0.24.0
 protobuf>=3.8.0
 pydot>=1.4.1
-pytest~=3.10.1
+pytest>=5.4.0
 pytest-cov>=2.6.0
 python-dateutil==2.8.0
 PyYAML>=5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pandas>=0.24.0
 protobuf>=3.8.0
 pydot>=1.4.1
 pytest>=5.4.0
-pytest-cov>=2.6.0
+pytest-cov>=2.8.0
 python-dateutil==2.8.0
 PyYAML>=5.1
 recommonmark>=0.6.0

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -534,6 +534,7 @@ def test_class_package():
             }
         }
     }
+    os.environ['PRIMROSE_EXT_NODE_PACKAGE'] = 'test'
     for config in [config_full_path, config_path, config_full_dot]:
         config = Configuration(config_location=None, is_dict_config=True, dict_config=config)
         assert config.config_string

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -6,6 +6,10 @@ from primrose.configuration.configuration import Configuration
 from primrose.writers.abstract_file_writer import AbstractFileWriter
 from primrose.node_factory import NodeFactory
 
+@pytest.fixture
+def mock_env(monkeypatch):
+    monkeypatch.setenv("PRIMROSE_EXT_NODE_PACKAGE", "test")
+
 def test_init_error0():
     config = {}
     with pytest.raises(Exception) as e:
@@ -463,7 +467,7 @@ implementation_config:
     """
     assert final_str == expected
 
-def test_class_prefix():
+def test_class_prefix(mock_env):
     config_path = {
         "implementation_config": {
             "reader_config": {
@@ -493,7 +497,7 @@ def test_class_prefix():
         NodeFactory().unregister('TestExtNode')
         
 
-def test_class_package():
+def test_class_package(mock_env):
     config_path = {
         "metadata": {
             "class_package": "test"
@@ -534,7 +538,6 @@ def test_class_package():
             }
         }
     }
-    os.environ['PRIMROSE_EXT_NODE_PACKAGE'] = 'test'
     for config in [config_full_path, config_path, config_full_dot]:
         config = Configuration(config_location=None, is_dict_config=True, dict_config=config)
         assert config.config_string
@@ -542,7 +545,7 @@ def test_class_package():
         NodeFactory().unregister('TestExtNode')
 
 
-def test_env_override_class_package():
+def test_env_override_class_package(mock_env):
     config = {
         "metadata": {
             "class_package": "junk"
@@ -556,12 +559,10 @@ def test_env_override_class_package():
             }
         }
     }
-    os.environ['PRIMROSE_EXT_NODE_PACKAGE'] = 'test'
     config = Configuration(config_location=None, is_dict_config=True, dict_config=config)
     assert config.config_string
     assert config.config_hash
     NodeFactory().unregister('TestExtNode')
-    os.environ.pop('PRIMROSE_EXT_NODE_PACKAGE')
 
 
 def test_incorrect_class_package():


### PR DESCRIPTION
Update pytest version.

## Description
Pytest was pinned to version 3.10. This conflicted with our newer pytest>=5.4.0 requirement for travis builds of our model mono-repo.
* updated pytest version
* updated pytest-cov too
* set the PRIMROSE_EXT_NODE_PACKAGE env var via monkeypatch to prevent a failure on local tests

<!--- 'Closes Issue #<number here> if applicable.' -->

### Types of change
bug fix, enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I squashed my commits to a reasonable number of descriptive commits.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

<!--- Note: I copied this from the Spacy repo, and modified sightly for our rules. So credit to them!-->