### PR TITLE
updating module prefix logic

### DIFF
--- a/primrose/configuration/configuration.py
+++ b/primrose/configuration/configuration.py
@@ -373,10 +373,9 @@ class Configuration:
 
         # loading from module
         else:
-            if self.config_metadata:
-                if 'class_package' in self.config_metadata:
-                    class_package = self.config_metadata['class_package']
-                    prefix = '.'.join(filter(None, [class_package, class_prefix]))
+            if self.config_metadata and 'class_package' in self.config_metadata:
+                class_package = self.config_metadata['class_package']
+                prefix = '.'.join(filter(None, [class_package, class_prefix]))
             else:
                 prefix = class_prefix
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ jstyleson==0.0.2
 matplotlib>=2.1.2
 moto>=1.3.7
 mysql-connector-python>=8.0.16
-networkx>=2.1
+networkx==2.1
 nltk>=3.2.5
 numpy>=1.16.4
 pandas>=0.24.0


### PR DESCRIPTION
One case of checking the prefix for module imports caused an undefined prefix. This change fixes this case so that the prefix is always defined.

### Types of change
Bugfix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I squashed my commits to a reasonable number of descriptive commits.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

<!--- Note: I copied this from the Spacy repo, and modified sightly for our rules. So credit to them!-->