### PR TITLE
Generic transformer pipeline

### DIFF
--- a/primrose/node_factory.py
+++ b/primrose/node_factory.py
@@ -27,7 +27,7 @@ from primrose.pipelines.dataframe_joiner import DataFrameJoiner
 from primrose.pipelines.encode_train_test_split import EncodeTrainTestSplit
 from primrose.pipelines.train_test_split import TrainTestSplit
 from primrose.pipelines.sklearn_preprocessing_pipeline import SklearnPreprocessingPipeline
-
+from primrose.pipelines.transformer_pipeline import TransformerPipeline
 from primrose.models.sklearn_classifier_model import SklearnClassifierModel
 from primrose.models.sklearn_cluster_model import SklearnClusterModel
 from primrose.models.sklearn_regression_model import SklearnRegressionModel
@@ -102,6 +102,7 @@ class NodeFactory:
                 'SklearnDatasetReader': SklearnDatasetReader,
                 'SklearnRegressionModel': SklearnRegressionModel,
                 'SimpleSwitch': SimpleSwitch,
+                'TransformerPipeline': TransformerPipeline,
                 'ClientNotification': ClientNotification,
                 'RReader': RReader}
 

--- a/primrose/pipelines/sklearn_preprocessing_pipeline.py
+++ b/primrose/pipelines/sklearn_preprocessing_pipeline.py
@@ -9,9 +9,12 @@ from primrose.base.transformer_sequence import TransformerSequence
 from primrose.transformers.sklearn_preprocessing_transformer import SklearnPreprocessingTransformer
 from primrose.data_object import DataObjectResponseType
 from primrose.pipelines.train_test_split import TrainTestSplit
+import warnings
+
 
 class SklearnPreprocessingPipeline(TrainTestSplit):
-
+    warnings.warn('SklearnPreprocessingPipeline will deprecated in a future release. Please use TransformerPipeline instead',
+        DeprecationWarning)
     @staticmethod
     def necessary_config(node_config):
         """Return the necessary configuration keys for the SklearnPreprocessingPipeline object

--- a/primrose/pipelines/transformer_pipeline.py
+++ b/primrose/pipelines/transformer_pipeline.py
@@ -1,0 +1,84 @@
+"""Module to run any sequence of transformers, both custom transformers and sklearn preprocessors.
+
+Author(s):
+    Carl Anderson (carl.anderson@weightwatchers.com)
+    Brian Graham (brian.graham@ww.com)
+
+"""
+import importlib
+import inspect
+from primrose.base.transformer_sequence import TransformerSequence
+from primrose.base.transformer import AbstractTransformer
+from primrose.pipelines.train_test_split import TrainTestSplit
+
+
+class TransformerPipeline(TrainTestSplit):
+
+    def __init__(self,configuration, instance_name):
+        super(TransformerPipeline,self).__init__(configuration, instance_name)
+        self.training_fraction = self.node_config.get("training_fraction", 0)
+        self.seed = self.node_config.get("seed",0)
+
+    @staticmethod
+    def necessary_config(node_config):
+        """Return the necessary configuration keys for the TransformerPipeline object
+
+        Returns:
+            set of keys
+
+        """
+        return set(['transformer_sequence'])
+
+    @staticmethod
+    def optional_config(node_config):
+        """Return the optional configuration keys for the TransformerPipeline object
+
+        Returns:
+            set of keys
+
+        """
+        return TrainTestSplit.necessary_config(node_config)
+
+    def init_pipeline(self):
+        """create the pipeline's TransformerSequence
+
+        Returns:
+            a TransformerSequence
+
+        """
+        ts = TransformerSequence()
+
+        for transformer in self.node_config["transformer_sequence"]:
+            transformer_args = transformer.get('args', None)
+            columns = transformer.get('columns', None)
+
+            p = self._instantiate_transformer(transformer)
+            ts.add(p)
+
+        return ts
+
+    @staticmethod
+    def _instantiate_transformer(transformer):
+        """Import and validate user-defined sklearn preprocessor
+
+        Returns:
+            AbstractTransformer
+
+        """
+        classname = transformer['class']
+        path_sequence = classname.split('.')
+        target_class_name = path_sequence.pop(-1)
+        module = importlib.import_module('.'.join(path_sequence))
+
+        try:
+            t = getattr(module, target_class_name)
+        except AttributeError:
+            raise Exception(f'Transformer {target_class_name} not found in {".".join(path_sequence)} module')
+
+        class_args = {k: v for k,v in transformer.items() if k != "class"}
+        params = [p for p in inspect.signature(t).parameters]
+        t_args = [class_args.pop(p) for p in params if p in class_args.keys()]
+
+        return t(*t_args, **class_args)
+
+

--- a/primrose/transformers/sklearn_preprocessing_transformer.py
+++ b/primrose/transformers/sklearn_preprocessing_transformer.py
@@ -2,8 +2,10 @@
 
 Author(s):
     Carl Anderson (carl.anderson@weightwatchers.com)
+    Brian Graham (brian.graham@ww.com)
 
 """
+import importlib
 import logging
 import pandas as pd
 
@@ -11,18 +13,34 @@ from primrose.base.transformer import AbstractTransformer
 
 class SklearnPreprocessingTransformer(AbstractTransformer):
 
-    def __init__(self, preprocessor, columns):
+    def __init__(self, preprocessor, columns, args=None):
         """initialize the proprocessor
 
         Args:
-            preprocessor (SKlearn preprocessor): preprocesor from Sklearn
+            preprocessor (SKlearn preprocessor or str specifying the preprocessor): preprocesor from Sklearn
             columns (list of str): list of columns
 
         """
         #Ideally, would check that this is a preprocessor but there is no good class to check against
-        self.preprocessor = preprocessor
+        self.preprocessor = self._instantiate_preprocessor(preprocessor,args)
         self.columns = columns
 
+    def _instantiate_preprocessor(self, preprocessor, args):
+        if isinstance(preprocessor, str):
+            sk_module_name, sk_transformer_name = preprocessor.split('.')
+            sk_module = importlib.import_module('sklearn.{}'.format(sk_module_name))
+
+            try:
+                t = getattr(sk_module, sk_transformer_name)
+            except AttributeError:
+                raise Exception('Preprocessor {} not found in {} module'.format(sk_transformer_name, sk_module_name))
+
+            if args:
+                return t(**args)
+
+            return t()
+
+        return preprocessor
     def fit(self, data):
         """User implements fit operation on a single data element from a data_object
         

--- a/test/test_transformer_pipeline.py
+++ b/test/test_transformer_pipeline.py
@@ -1,0 +1,83 @@
+import pytest
+from primrose.base.transformer_sequence import TransformerSequence
+from primrose.configuration.configuration import Configuration
+from primrose.data_object import DataObject
+from primrose.pipelines.transformer_pipeline import TransformerPipeline
+from primrose.readers.csv_reader import CsvReader
+from primrose.transformers.sklearn_preprocessing_transformer import SklearnPreprocessingTransformer
+from primrose.transformers.strings import StringTransformer
+def test__instantiate_transformer_1():
+    processor = TransformerPipeline._instantiate_transformer(
+        {
+            "class": "primrose.transformers.sklearn_preprocessing_transformer.SklearnPreprocessingTransformer",
+            "preprocessor": "preprocessing.StandardScaler",
+            "columns":["test"],
+            "kwargs": {"with_mean": False}
+        })
+    assert isinstance(processor, SklearnPreprocessingTransformer)
+    assert processor.preprocessor.with_mean == False
+
+    with pytest.raises(Exception) as e:
+        TransformerPipeline._instantiate_transformer({"class": "sklearn.preprocessing.junk"})
+    assert "Transformer junk not found in sklearn.preprocessing module" in str(e)
+
+
+def test_necessary_config():
+    assert "transformer_sequence" in TransformerPipeline.necessary_config({})
+
+def test_optional_config():
+    assert TransformerPipeline.optional_config({}) == {"training_fraction", "seed", "is_training"}
+
+@pytest.fixture
+def config():
+    config = {
+      "implementation_config": {
+        "reader_config": {
+          "read_data": {
+            "class": "CsvReader",
+            "filename": "data/tennis.csv",
+            "destinations": [
+              "transformers"
+            ]
+          }
+        },
+        "pipeline_config": {
+          "transformers": {
+            "class": "TransformerPipeline",
+            "transformer_sequence": [{
+                "class": "primrose.transformers.strings.StringTransformer",
+                "method": "replace",
+                "columns": "outlook",
+                "pat": "sunny",
+                "repl":"rainy"
+
+            }]
+          }
+        }
+      }
+    }
+    configuration = Configuration(None, is_dict_config=True, dict_config=config)
+    return configuration
+
+@pytest.fixture
+def data_object(config):
+    data_object = DataObject(config)
+    csv_reader = CsvReader(config, "read_data")
+    data_object, _ = csv_reader.run(data_object)
+    return data_object
+
+@pytest.fixture
+def pipeline(config):
+    return TransformerPipeline(config, "transformers")
+
+def test__init__(pipeline):
+    assert isinstance(pipeline, TransformerPipeline)
+
+def test_init_pipeline(pipeline):
+    ts = pipeline.init_pipeline()
+    assert isinstance(ts, TransformerSequence)
+    assert isinstance(ts.sequence[0], StringTransformer)
+
+def test_transform(pipeline,data_object):
+    data_object, _ = pipeline.run(data_object)
+    assert data_object.data_dict['transformers']['data_test']['outlook'].loc[0] == "rainy"

--- a/test/test_transformer_pipeline.py
+++ b/test/test_transformer_pipeline.py
@@ -12,7 +12,7 @@ def test__instantiate_transformer_1():
             "class": "primrose.transformers.sklearn_preprocessing_transformer.SklearnPreprocessingTransformer",
             "preprocessor": "preprocessing.StandardScaler",
             "columns":["test"],
-            "kwargs": {"with_mean": False}
+            "args": {"with_mean": False}
         })
     assert isinstance(processor, SklearnPreprocessingTransformer)
     assert processor.preprocessor.with_mean == False


### PR DESCRIPTION
Adds a pipeline that lets you specify a transformer sequence from config files.

## Description
We have many transformers both in primrose and our private repo. If you need to use one to many transformers, but require no other manipulation of your data outside of the transformer capability, you would need to write another python pipeline node to accomplish this.  This can lead to a lot of bloat of pipeline classes that are just instantiating and running transformers.  Instead os using python, we should be able to specify a sequence of transformers from a config file using the new TransformerPipeline Node.

This node was inspired by the SklearnPreprocessingPipeline node, and can handle instantiation of our sklearn transformer wrapper around sklearn preprocesses, along with any of our custom transformers, so long as all the input args for a transformer can be read in from a config file.  The design pattern for tranformers moving forward should be to only allow inputs that are types that can be read in from a config file. I modified the SklearnPreprocessingTransformer to also allow string specification of the sklearn preprocessing class instead of passing a python object to avoid breaking changes and also allow that class to be used in a transformer sequence in the new TransformerPipeline node.

Here's an example of the new syntax including a custom string processing node and the slightly different way you would use an sklearn preprocessor with the new TransformerPipeline node.

```
"pipeline_config": {
          "transformers": {
            "class": "TransformerPipeline",
            "transformer_sequence": [
                {
                    "class": "primrose.transformers.strings.StringTransformer",
                    "method": "replace",
                    "columns": "outlook",
                    "pat": "sunny",
                    "repl":"rainy"

                },
                {
                    "class": "primrose.transformers.sklearn_preprocessing_transformer.SklearnPreprocessingTransformer",
                    "preprocessor": "preprocessing.StandardScaler",
                    "columns": ["id"],
                    "args": {"with_mean": False}
                }
            ]
          }
        }
```

<!--- 'Closes Issue #<number here> if applicable.' -->

### Types of change
new feature

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I squashed my commits to a reasonable number of descriptive commits.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

<!--- Note: I copied this from the Spacy repo, and modified sightly for our rules. So credit to them!-->