### PR TITLE
env var substitution in jinja template

### DIFF
--- a/primrose/configuration/configuration.py
+++ b/primrose/configuration/configuration.py
@@ -151,7 +151,10 @@ class Configuration:
             config_str (str): the post-substituted configuration string
 
         """
+        def env_override(value, key):
+            return os.getenv(key, value)
         jinja_env = Environment(loader=FileSystemLoader([".", "/"]))
+        jinja_env.filters['env_override'] = env_override
         try:
             config_str_template = jinja_env.from_string(config_str)
             config_str = config_str_template.render()

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,6 @@ Sphinx>=2.3.0
 sphinxcontrib-napoleon==0.7
 sphinx-rtd-theme>=0.4.3
 testfixtures>=6.8.2
+six==1.13.0
+
+

--- a/test/metadata_fragment.json
+++ b/test/metadata_fragment.json
@@ -1,1 +1,3 @@
-        "metadata":{},
+        "metadata":{
+                "test": "{{ "default" | env_override("TEST") }}"
+        },

--- a/test/metadata_fragment.yml
+++ b/test/metadata_fragment.yml
@@ -1,2 +1,2 @@
 metadata:
-  test : {{ "default" | env("TEST") }}
+  test: {{ "default" | env_override("TEST") }}

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -390,7 +390,7 @@ def test_perform_any_config_fragment_substitution_bad():
     assert "Substitution files do not exist: does/not/exist" in str(e)
 
 
-def test_perform_any_config_fragment_substitution():
+def test_perform_any_config_fragment_substitution_default():
     config_str = """
     {
         {% include "test/metadata_fragment.json" %}
@@ -402,7 +402,9 @@ def test_perform_any_config_fragment_substitution():
     final_str = Configuration.perform_any_config_fragment_substitution(config_str)
     expected = """
     {
-        "metadata":{},
+        "metadata":{
+            "test": "default"
+        },
         "implementation_config": {
 
         "reader_config": {
@@ -422,12 +424,52 @@ def test_perform_any_config_fragment_substitution():
                 "filename": "tennis_output.csv"
             }
         }
-        
+
         }
     }
     """
     assert json.loads(final_str) == json.loads(expected)
 
+def test_perform_any_config_fragment_substitution_env_var(monkeypatch):
+    monkeypatch.setenv("TEST","foo")
+    config_str = """
+    {
+        {% include "test/metadata_fragment.json" %}
+        "implementation_config": {
+            {% include "test/read_write_fragment.json" %}
+        }
+    }
+    """
+    final_str = Configuration.perform_any_config_fragment_substitution(config_str)
+    expected = """
+    {
+        "metadata":{
+            "test": "foo"
+        },
+        "implementation_config": {
+
+        "reader_config": {
+            "read_data": {
+                "class": "CsvReader",
+                "filename": "data/tennis.csv",
+                "destinations": [
+                    "write_output"
+                ]
+            }
+        },
+        "writer_config": {
+            "write_output": {
+                "class": "CsvWriter",
+                "key": "data",
+                "dir": "cache",
+                "filename": "tennis_output.csv"
+            }
+        }
+
+        }
+    }
+    """
+    assert json.loads(final_str) == json.loads(expected)
 
 def test_yaml_config1():
     config_yaml = Configuration(config_location="test/hello_world_tennis.yml")
@@ -449,8 +491,8 @@ implementation_config:
     """
     final_str = Configuration.perform_any_config_fragment_substitution(config_str)
     expected = """
-metadata: 
-    test: default
+metadata:
+  test: default
 implementation_config:
   reader_config:
     read_data:
@@ -476,8 +518,8 @@ implementation_config:
     """
     final_str = Configuration.perform_any_config_fragment_substitution(config_str)
     expected = """
-metadata: 
-    test: foo
+metadata:
+  test: foo
 implementation_config:
   reader_config:
     read_data:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
Add functionality to perform environment variable substitution in configuration file fragment substitution.

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
In the current configuration parser, we added a step in the configuration file fragment substitution function to check for environment variables and substitute them as fit. The method we used to access env vars from jinja template is detailed in the  post: https://stackoverflow.com/a/25864212

With this approach, env vars can be substituted in both the main config files and any fragment files. 

Huge thanks to @briangrahamww to guide me throughout the process!!!

<!--- 'Closes Issue #<number here> if applicable.' -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I squashed my commits to a reasonable number of descriptive commits.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

<!--- Note: I copied this from the Spacy repo, and modified sightly for our rules. So credit to them!-->