### PR TITLE
sklearn version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pytest-cov>=2.8.0
 python-dateutil==2.8.0
 PyYAML>=5.1
 recommonmark>=0.6.0
-scikit-learn>=0.21.2
+scikit-learn>=0.21.2,<=0.23.2
 slackclient==2.4.0
 Sphinx>=2.3.0
 sphinxcontrib-napoleon==0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ mysql-connector-python>=8.0.16
 networkx==2.1
 nltk>=3.2.5
 numpy>=1.16.4
-pandas>=0.24.0
+pandas>=0.24.0,<=1.1.5
 pre-commit>=1.20.0
 protobuf>=3.8.0
 pydot>=1.4.1


### PR DESCRIPTION
## Description
Travis crashing and test crashing due to missing module in updated version of sklearn, thus, we fix the version of sklearn allowed to be installed. 

closes issue #99 

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I squashed my commits to a reasonable number of descriptive commits.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

<!--- Note: I copied this from the Spacy repo, and modified sightly for our rules. So credit to them!-->