### PR TITLE
Add message label to error notifications

### DIFF
--- a/README_NOTIFICATIONS.md
+++ b/README_NOTIFICATIONS.md
@@ -43,7 +43,7 @@ notification:
 
 ## Error Notifications
 
-To get notified if your job fails at any point in the DAG, you will need to create a `notify_on_error` key in the `metadata` section of the DAG. As above, this will require specifiying the `client`, `channel`, and `token`. `member_id` and `message` are optional. An example configuration would like this
+To get notified if your job fails at any point in the DAG, you will need to create a `notify_on_error` key in the `metadata` section of the DAG. As above, this will require specifying the `client`, `channel`, and `token`. `member_id` and `message` are optional. An example configuration would look like this
 
 ```
 metadata:
@@ -60,7 +60,7 @@ implementation_config:
       filename: data/tennis.csv
 ```
 
-The  `notify_on_error` key triggers the DAG runner to instantiate your client with the given parameters, and will post to `name-of-channel` upon hitting an error.  Specifically, it will preface the error message with the value of `message` in the your `notify_on_error` keys (this is defaulted to `Job error`, if you leave out the `message` key). For example, if `data/tennis.csv` does not exist, your app will post `Job Name 123: Issue with read_data`, followed by the traceback message. This is useful in identifying which of your DAGs has the error if you have multiple jobs posting to the same channel. 
+The  `notify_on_error` key triggers the DAG runner to instantiate your client with the given parameters, and will post to `name-of-channel` upon hitting an error.  Specifically, it will preface the error message with the value of `message` in the your `notify_on_error` keys (this is defaulted to `Job error` if you leave out the `message` key). For example, if `data/tennis.csv` does not exist, your app will post `Job Name 123: Issue with read_data`, followed by the traceback message. This is useful in identifying which of your DAGs has the error if you have multiple jobs posting to the same channel. 
 
 ## Environment Variables
 

--- a/README_NOTIFICATIONS.md
+++ b/README_NOTIFICATIONS.md
@@ -60,8 +60,7 @@ implementation_config:
       filename: data/tennis.csv
 ```
 
-The  `notify_on_error` key triggers the DAG runner to instantiate your client with the given parameters, and will post to `name-of-channel` upon hitting an error.
-Specifically, it will preface the error message with the value of `message` in the your `notify_on_error` keys (this is defaulted to `Job error`, if you leave out the `message` key). For example, if `data/tennis.csv` does not exist, your app will post `Job Name 123: Issue with read_data`, followed by the traceback message. This is useful in identifying which of your DAGs has the error if you have multiple jobs posting to the same channel. 
+The  `notify_on_error` key triggers the DAG runner to instantiate your client with the given parameters, and will post to `name-of-channel` upon hitting an error.  Specifically, it will preface the error message with the value of `message` in the your `notify_on_error` keys (this is defaulted to `Job error`, if you leave out the `message` key). For example, if `data/tennis.csv` does not exist, your app will post `Job Name 123: Issue with read_data`, followed by the traceback message. This is useful in identifying which of your DAGs has the error if you have multiple jobs posting to the same channel. 
 
 ## Environment Variables
 

--- a/README_NOTIFICATIONS.md
+++ b/README_NOTIFICATIONS.md
@@ -2,7 +2,9 @@
 
 A useful feature of `primrose` is the ability to get notified when your job is complete (or at any node, for that matter) and/or if there were errors in running your DAG. These two cases are handled slightly differently. Note that the current implementation is only set up to handle [Slack](https://slack.com/intl/en-ca/) notifications.
 
-To get started, you'll want to create a [`Slack App`](https://api.slack.com/apps?new_app=1) if you don't already have one. You'll be given an `OAuth Access Token`, and you'll have to choose a `slack channel` associated to the app. This is where your notifications will be posted.
+To get started, you'll want to create a [`Slack App`](https://api.slack.com/apps?new_app=1), if you don't already have one. The Slack [docs](https://api.slack.com/authentication/basics) go through the setup in detail. This can then be used by your whole team and added to multiple channels. If you are using an existing app, you will need the `User OAuth Token`. 
+
+If you are creating your own app, navigate to `OAuth & Permissions` in the sidebar and scroll to the `Scopes` section. Click on `Add an OAuth Scope` to add your scopes. You will want to include the `chat:write:bot` scope to allow your app to post messages, and the `incoming-webhook` scope to allow messages to be posted in specific channels. When "installing" your app, you'll have to choose a `slack channel` associated to the app. This is where your notifications will be posted. You can also do this directly in Slack by navigating to your channel `Details`, clicking on the `More` option, and choosing `Add apps` from the drop down.
 
 ## DAG Notifications
 
@@ -20,18 +22,20 @@ implementation_config:
     notification:
       class: ClientNotification
       client: SlackClient
-      channel: my-channel
+      channel: name-of-channel
       token: slack-token
       message: We did it!
 ```
 
-This DAG will read the file `data/tennis.csv` and store it in the `data_object` as a pandas dataframe. It will then post the message "We did it" in the `my-channel` slack channel. If you would like to get pinged on the notification, add your `member/user_id` as a parameter. Note that this is NOT your user name, but a string of the format "W012A3CDE" typically beginning with "U" or "W". The notification portion of your DAG would then look like
+This DAG will read the file `data/tennis.csv` and store it in the `data_object` as a pandas dataframe. It will then post the message "We did it" in the `name-of-channel` slack channel. If you would like to get pinged on the notification, add your `member_id` as a parameter. Note that this is NOT your user name, but a string of the format "W012A3CDE" typically beginning with "U" or "W". You can find your slack `member ID` by navigating to your `Profile` and choosing the `More` option. You will see your `member ID`in the drop down.
+
+The notification portion of your DAG would then look like
 
 ```
 notification:
     class: ClientNotification
     client: SlackClient
-    channel: my-channel
+    channel: name-of-channel
     token: slack-token
     member_id: W012A3CDE
     message: We did it!
@@ -39,15 +43,16 @@ notification:
 
 ## Error Notifications
 
-To get notified if your job fails at any point in the DAG, you will need to create a `notify_on_error` key in the `metadata` section of the DAG. As above, this will require specifiying the `client`, `channel`, and `token`. `member_id` is optional. An example configuration would like this
+To get notified if your job fails at any point in the DAG, you will need to create a `notify_on_error` key in the `metadata` section of the DAG. As above, this will require specifiying the `client`, `channel`, and `token`. `member_id` and `message` are optional. An example configuration would like this
 
 ```
 metadata:
   notify_on_error:
     client: SlackClient
-    channel: my-channel
+    channel: name-of-channel
     member_id: W012A3CDE
     token: slack-token
+    message: Job Name 123
 implementation_config:
   reader_config:
     read_data:
@@ -55,14 +60,15 @@ implementation_config:
       filename: data/tennis.csv
 ```
 
-The  `notify_on_error` key triggers the DAG runner to instantiate your client with the given parameters, and will post to `my-channel` upon hitting an error.
+The  `notify_on_error` key triggers the DAG runner to instantiate your client with the given parameters, and will post to `name-of-channel` upon hitting an error.
+Specifically, it will preface the error message with the value of `message` in the your `notify_on_error` keys (this is defaulted to `Job error`, if you leave out the `message` key). For example, if `data/tennis.csv` does not exist, your app will post `Job Name 123: Issue with read_data`, followed by the traceback message. This is useful in identifying which of your DAGs has the error if you have multiple jobs posting to the same channel. 
 
 ## Environment Variables
 
 If you would (understandably) prefer to have your configuration file read in the values of the client's parameters using environment variables, store your environment variables in the form "{CLIENT_NAME}_{CLIENT_KEY}". For example, for the `primrose` `SlackClient`, our variables would be stored as
 ```
 SLACKCLIENT_TOKEN="some-token"
-SLACKCLIENT_CHANNEL="some-channel"
+SLACKCLIENT_CHANNEL="some-channel-name"
 SLACKCLIENT_MEMBER_ID="USomeUserID"
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
If multiple DAGs are posting error notifications in the same channel, the previous setup was to just post the node name and the traceback message. However if multiple DAGs use the same node name, it is difficult to determine which DAG gave the error. This PR allows the user to add a `message` that will preface any traceback errors. It can be used to provide job names/ids or any other desired text. We add this change to the `README_NOTIFICATIONS.md` docs and also modify the docs to (hopefully) more clearly explain the slack integration.

<!--- 'Closes Issue #<number here> if applicable.' -->

### Types of change
Enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I squashed my commits to a reasonable number of descriptive commits.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

<!--- Note: I copied this from the Spacy repo, and modified sightly for our rules. So credit to them!-->